### PR TITLE
Update 2019-10-25-tool_ngram_browser.markdown

### DIFF
--- a/_posts/2019-10-25-tool_ngram_browser.markdown
+++ b/_posts/2019-10-25-tool_ngram_browser.markdown
@@ -34,7 +34,7 @@ categories: Lab
 
 <p class="instructions">Please note that we do put a limit on the complexity of queries.  If you exceed those limits, we return what we can, and provide a message to that effect.</p>
 
-<p class="instructions">For more about regular expressions, please see our post on <a href="howtoeebospellingbrowser.html">Using the N-gram Browser</a>.  For a full list of the nupos part-of-speech codes, please see  the section titled "Parts of Speech Table" in <a href="https://apps.lis.illinois.edu/wiki/display/MONK/Morphology+and+NUPOS">Morphology and NUPOS</a>, an article written by John Norstad.</p>
+<p class="instructions">For more about regular expressions, please see our post on <a href="howtoeebospellingbrowser.html">Using the N-gram Browser</a>. For more on part-of-speech tags, please see the <a href="http://morphadorner.northwestern.edu/morphadorner/documentation/nupos/">NUPOS documentation</a>.</p>
 
 <hr/>
 <br/>


### PR DESCRIPTION
The link to John Norstad's article is dead. I've replaced it with a link to the MorphAdorner/NUPOS documentation, which contains the NUPOS tagset along with some explanatory material. This looks to be a solid NUPOS reference with a stable link: http://morphadorner.northwestern.edu/morphadorner/documentation/nupos/